### PR TITLE
Native to check if an entity is a Special Item.

### DIFF
--- a/addons/sourcemod/scripting/entWatch.sp
+++ b/addons/sourcemod/scripting/entWatch.sp
@@ -108,6 +108,7 @@ public APLRes:AskPluginLoad2(Handle:hThis, bool:bLate, String:sError[], err_max)
 	CreateNative("entWatch_IsClientBanned", Native_IsClientBanned);
 	CreateNative("entWatch_BanClient", Native_BanClient);
 	CreateNative("entWatch_UnbanClient", Native_UnbanClient);
+	CreateNative("entWatch_IsSpecialItem", Native_IsSpecialItem);
 	
 	RegPluginLibrary("entWatch");
 	
@@ -1987,4 +1988,28 @@ public Native_UnbanClient(Handle:hPlugin, iArgC)
 	EUnbanClient(client, 0);
 	
 	return true;
+}
+
+public Native_IsSpecialItem(Handle:hPlugin, iArgC)
+{
+	if (!G_bConfigLoaded)
+	{
+		return false;
+	}
+	
+	new entity = GetNativeCell(1);
+	if (entity < MaxClients || !IsValidEdict(entity) || !IsValidEntity(entity))
+	{
+		return false;
+	}
+
+	for (new index = 0; index < entArraySize; index++)
+	{
+		if (entArray[index][ent_buttonid] == entity)
+		{
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/addons/sourcemod/scripting/include/entWatch.inc
+++ b/addons/sourcemod/scripting/include/entWatch.inc
@@ -37,6 +37,14 @@ native bool:entWatch_BanClient(client, bool:bIsTemporary=false, iLength=0);
 native bool:entWatch_UnbanClient(client);
 
 /**
+ * Checks if an entity is a special item.
+ * 
+ * @param entity		Entity index to check
+ * @return				True if entity is a special item, false otherwsie
+ */
+native bool:entWatch_IsSpecialItem(entity);
+
+/**
  * Called when a client is e-banned by any means
  * 
  * @param admin			Admin index that issued the ban
@@ -110,5 +118,7 @@ public __pl_entWatch_SetNTVOptional()
 {
 	MarkNativeAsOptional("entWatch_IsClientBanned");
 	MarkNativeAsOptional("entWatch_BanClient");
+	MarkNativeAsOptional("entWatch_UnbanClient");
+	MarkNativeAsOptional("entWatch_IsSpecialItem");
 }
 #endif


### PR DESCRIPTION
Native to check if an entity is a Special Item:
```sourcepawn
native bool:entWatch_IsSpecialItem(entity);
```
Could be usefull for plugin developers.


I've also added missing 
```sourcepawn
MarkNativeAsOptional("entWatch_UnbanClient");
```
to `entWatch.inc` file.