### PR TITLE
Several minor fixes

### DIFF
--- a/addons/sourcemod/scripting/entWatch.sp
+++ b/addons/sourcemod/scripting/entWatch.sp
@@ -1612,7 +1612,7 @@ public Action:Command_Transfer(client, args)
 	}
 	
 	CPrintToChatAll("\x07%s[entWatch] \x07%s%N \x07%stransfered all items from \x07%s%N \x07%sto \x07%s%N", color_tag, color_name, client, color_warning, color_name, target, color_warning, color_name, reciever);
-	LogAction(client, -1, "\"%L\" transfered all items from \"%L\" to \"%L\"", client, target, reciever);
+	LogAction(client, target, "\"%L\" transfered all items from \"%L\" to \"%L\"", client, target, reciever);
 	
 	return Plugin_Handled;
 }


### PR DESCRIPTION
First of all I've added client data initialization when the entWatch plugin was loaded after server start.

Special items data cleaning is calling 2 times (in OnMapStart and on Reload Command), so it should be separated to it's own function.

In config loading section the LogMessage used to print the `buffer_path` always, but sometimes we use an override configs.